### PR TITLE
routerの実装

### DIFF
--- a/back/handlers/handlers.go
+++ b/back/handlers/handlers.go
@@ -28,7 +28,6 @@ func (h Handler) Search(c *gin.Context) {
 
 	if err != nil {
 		c.String(http.StatusInternalServerError, "Internal Server Error")
-		log.Fatal(err)
 		return
 	}
 
@@ -47,7 +46,6 @@ func (h Handler) ItemList(c *gin.Context) {
 	search_result, err := h.db.SearchItemsArea(search_query.Location1, search_query.Location2)
 	if err != nil {
 		c.String(http.StatusInternalServerError, "Internal Server Error")
-		log.Fatal(err)
 		return
 	}
 
@@ -65,7 +63,6 @@ func (h Handler) ItemDetail(c *gin.Context) {
 	item_detail, err := h.db.ItemDetail(uint64(item_id))
 	if err != nil {
 		c.String(http.StatusInternalServerError, "Internal Server Error")
-		log.Fatal(err)
 		return
 	}
 

--- a/back/main.go
+++ b/back/main.go
@@ -1,30 +1,10 @@
 package main
 
 import (
-	"lost-item/db"
-
-	"github.com/gin-gonic/gin"
+	"lost-item/router"
 )
-// サンプル
-type ss struct {
-	i int
-}
-func main() {
-	d := &db.Association{}
-	d.Open()
-	//サンプル
-	// テーブル
-	d.DB.AutoMigrate(&ss{})
-	// insert
-	d.DB.Create(&ss{
-		i:1,
-	})
 
-	r := gin.Default()
-	r.GET("/ping", func(c *gin.Context) {
-		c.JSON(200, gin.H{
-			"message": "pong",
-		})
-	})
+func main() {
+	r := router.Router()
 	r.Run(":3000")
 }

--- a/back/router/router.go
+++ b/back/router/router.go
@@ -10,6 +10,11 @@ func Router() *gin.Engine {
 	r := gin.Default()
 	h := handlers.Handler{}
 	h.Init()
-	r.GET("/serch",h.Search)
+	r.GET("/item_list",h.ItemList)
+	r.GET("/item",h.ItemDetail)
+	r.POST("/item",h.RegisterItem)
+	r.DELETE("/item",h.DeleteItem)
+	r.POST("/parse",h.Search)
+	r.POST(" /image",h.RegisterImage)
 	return r
 }

--- a/back/router/router.go
+++ b/back/router/router.go
@@ -10,11 +10,11 @@ func Router() *gin.Engine {
 	r := gin.Default()
 	h := handlers.Handler{}
 	h.Init()
-	r.GET("/item_list",h.ItemList)
-	r.GET("/item",h.ItemDetail)
-	r.POST("/item",h.RegisterItem)
-	r.DELETE("/item",h.DeleteItem)
-	r.POST("/parse",h.Search)
-	r.POST(" /image",h.RegisterImage)
+	r.GET("/item_list", h.ItemList)
+	r.GET("/item", h.ItemDetail)
+	r.POST("/item", h.RegisterItem)
+	r.DELETE("/item", h.DeleteItem)
+	r.POST("/parse", h.Search)
+	r.POST(" /image", h.RegisterImage)
 	return r
 }

--- a/back/router/router.go
+++ b/back/router/router.go
@@ -1,0 +1,15 @@
+package router
+
+import (
+	"lost-item/handlers"
+
+	"github.com/gin-gonic/gin"
+)
+
+func Router() *gin.Engine {
+	r := gin.Default()
+	h := handlers.Handler{}
+	h.Init()
+	r.GET("/serch",h.Search)
+	return r
+}


### PR DESCRIPTION
<!--
不要な場合は削除してください
-->

## タスク
- routerの実装
- severの実行中に`log.Fatalf`が使用されていたものを消した。理由としてlog.Fatalfのなかには`os.Exit(1)`が入っているためサーバーが停止してしまうためである。
<!--
何を実装しますか？
-->

## 仕様
- main関数からrouterに飛ぶようにした
- router内でGET等を呼べるようにした
- sever実行中に使われそうなのlog.Fatalf 消した
<!--
どのようにを実装しましたか？
-->

## 動作確認
<img width="826" alt="image" src="https://user-images.githubusercontent.com/108039575/222858749-276a80ae-07bb-416f-a465-eeefadeae6d5.png">
<img width="1064" alt="image" src="https://user-images.githubusercontent.com/108039575/222859888-6ea1d845-5b68-4f49-b33a-e5c5b84a89ed.png">

現在は何か取っているわけではないからbadとなるが動いた
なおSearchItemsForなどのメソッドにちりあえず `return model.SearchResult{}, nil`を返したことで動く。このPRでは動作確認の時に追加しただけである
<!--
何をチェックしましたか？
-->

## チェックシート
- [x] 他の人が見ても読みやすいコードを書いた
- [x] コードを読んでも分かりにくいところはコメントをのこした
- [x] 動作確認で動いた
