### PR TITLE
tagsが空である時に[""]と返してしまうため[]と返すように変更する

### DIFF
--- a/back/handlers/handlers.go
+++ b/back/handlers/handlers.go
@@ -76,6 +76,13 @@ func (h Handler) ItemDetail(c *gin.Context) {
 		return
 	}
 
+	for _, v := range item_detail.Kinds {
+		if 0 == len(v) {
+			item_detail.Kinds = make([]string, 0)
+		}
+		break
+	}
+
 	c.JSON(http.StatusOK, item_detail)
 }
 

--- a/back/handlers/handlers.go
+++ b/back/handlers/handlers.go
@@ -59,7 +59,7 @@ func (h Handler) Search(c *gin.Context) {
 	}
 
 	for _, v := range search_result.Items {
-		if 0 == len(v.Kinds[0]) {
+		if "" == v.Kinds[0] {
 			search_result.Items[0].Kinds = make([]string, 0)
 		}
 	}
@@ -82,7 +82,7 @@ func (h Handler) ItemDetail(c *gin.Context) {
 		return
 	}
 
-	if 0 == len(item_detail.Kinds[0]) {
+	if "" == item_detail.Kinds[0] {
 		item_detail.Kinds = make([]string, 0)
 	}
 

--- a/back/handlers/handlers.go
+++ b/back/handlers/handlers.go
@@ -59,13 +59,9 @@ func (h Handler) Search(c *gin.Context) {
 	}
 
 	for _, v := range search_result.Items {
-		for i, kind := range v.Kinds {
-			if 0 == len(kind) {
-				search_result.Items[i].Kinds = make([]string, 0)
-			}
-			break
+		if 0 == len(v.Kinds[0]) {
+			search_result.Items[0].Kinds = make([]string, 0)
 		}
-		break
 	}
 
 	c.JSON(http.StatusOK, search_result)
@@ -86,11 +82,8 @@ func (h Handler) ItemDetail(c *gin.Context) {
 		return
 	}
 
-	for _, v := range item_detail.Kinds {
-		if 0 == len(v) {
-			item_detail.Kinds = make([]string, 0)
-		}
-		break
+	if 0 == len(item_detail.Kinds[0]) {
+		item_detail.Kinds = make([]string, 0)
 	}
 
 	c.JSON(http.StatusOK, item_detail)

--- a/back/handlers/handlers.go
+++ b/back/handlers/handlers.go
@@ -58,6 +58,16 @@ func (h Handler) Search(c *gin.Context) {
 		return
 	}
 
+	for _, v := range search_result.Items {
+		for i, kind := range v.Kinds {
+			if 0 == len(kind) {
+				search_result.Items[i].Kinds = make([]string, 0)
+			}
+			break
+		}
+		break
+	}
+
 	c.JSON(http.StatusOK, search_result)
 }
 


### PR DESCRIPTION
<!--
不要な場合は削除してください
-->

## タスク
/search,/item/:id においてtagsが空である時に`[""]`と返してしまうため`[]`と返すように変更する
<!--
何を実装しますか？
-->

## 仕様
tagsの部分の文字列の長さが0の時にtagsにサイズ0のstringのスライスを代入した
<!--
どのようにを実装しましたか？
-->

## 動作確認

<!--
何をチェックしましたか？
-->
<img width="443" alt="image" src="https://user-images.githubusercontent.com/108039575/222948421-7fa55f29-5174-4d9d-b1ae-cd77989e28d6.png">

<img width="484" alt="image" src="https://user-images.githubusercontent.com/108039575/222948392-6a54d849-8a61-4774-98c2-4d0574c292ba.png">

## チェックシート
- [x] 他の人が見ても読みやすいコードを書いた
- [x] コードを読んでも分かりにくいところはコメントをのこした
- [x] 動作確認で動いた
