### PR TITLE
物品名や色・状況・その他をPOST /item/:idから登録できるようにした

### DIFF
--- a/back/database/postgresd/postgresd.go
+++ b/back/database/postgresd/postgresd.go
@@ -149,13 +149,17 @@ func (d *Postgresd) CompleteItem(id uint64) error {
 
 func (d *Postgresd) InsertItem(item model.LostItem) (model.LostItem, error) {
 	item_db := database.LostItem{
-		Model:    gorm.Model{ID: item.ID},
-		Kinds:    strings.Join(item.Kinds, ","),
-		Comment:  item.Comment,
-		ImageURL: item.ImageURL,
-		Lat:      item.Location.Lat,
-		Lng:      item.Location.Lng,
-		FindTime: item.FindTime,
+		Model:     gorm.Model{ID: item.ID},
+		Kinds:     strings.Join(item.Kinds, ","),
+		Comment:   item.Comment,
+		ImageURL:  item.ImageURL,
+		Lat:       item.Location.Lat,
+		Lng:       item.Location.Lng,
+		FindTime:  item.FindTime,
+		ItemName:  item.ItemName,
+		Colour:    item.Colour,
+		Situation: item.Situation,
+		Others:    item.Others,
 	}
 
 	if err := d.conn.Create(&item_db).Error; err != nil {

--- a/back/database/postgresd/postgresd.go
+++ b/back/database/postgresd/postgresd.go
@@ -29,7 +29,11 @@ func toModelLostItem(item database.LostItem) model.LostItem {
 			Lat: item.Lat,
 			Lng: item.Lng,
 		},
-		FindTime: item.FindTime,
+		FindTime:  item.FindTime,
+		ItemName:  item.ItemName,
+		Colour:    item.Colour,
+		Situation: item.Situation,
+		Others:    item.Others,
 	}
 }
 

--- a/back/model/item.go
+++ b/back/model/item.go
@@ -3,12 +3,16 @@ package model
 import "time"
 
 type LostItem struct {
-	ID       uint      `json:"id"`
-	Kinds    []string  `json:"tags" binding:"required"`
-	Comment  string    `json:"note"`
-	ImageURL string    `json:"pic" binding:"required"`
-	Location Location  `json:"location" binding:"required"`
-	FindTime time.Time `json:"date" time_format:"2006-01-02T15:04:05Z" binding:"required"`
+	ID        uint      `json:"id"`
+	Kinds     []string  `json:"tags" binding:"required"`
+	Comment   string    `json:"note"`
+	ImageURL  string    `json:"pic" binding:"required"`
+	Location  Location  `json:"location" binding:"required"`
+	FindTime  time.Time `json:"date" time_format:"2006-01-02T15:04:05Z" binding:"required"`
+	ItemName  string    `json:"item_name"`
+	Colour    string    `json:"colour"`
+	Situation string    `json:"situation"`
+	Others    string    `json:"others"`
 }
 
 type Location struct {


### PR DESCRIPTION
#40終了後にレビュー
Close #41

## タスク

#41

## 仕様

[Notion](https://www.notion.so/API-dd98058817d2487ca81acf8821429d6c#:~:text=Shell-,%E8%90%BD%E3%81%A8%E3%81%97%E7%89%A9%E3%82%92%E7%99%BB%E9%8C%B2%E3%81%99%E3%82%8B,-POST%20/item%0A%0Abody)

## 動作確認

Postmanを使って、登録するエンドポイントをたたいた

## チェックシート
- [x] 他の人が見ても読みやすいコードを書いた
- [] コードを読んでも分かりにくいところはコメントをのこした
- [x] 動作確認で動いた
