### PR TITLE
searchのwhereを修正

### DIFF
--- a/back/database/postgresd/postgresd.go
+++ b/back/database/postgresd/postgresd.go
@@ -94,20 +94,25 @@ func (d *Postgresd) Search(left_upper model.Location, right_bottom model.Locatio
 		bottom, upper = swap(bottom, upper)
 	}
 
-	db := d.conn.Where("? <= Lat AND Lat <= ? AND ? <= Lng AND Lng <= ?", bottom, upper, left, right)
-	if query != "" {
-		db = d.conn.Where("Comment LIKE ?", "%"+query+"%")
-		db = d.conn.Where("Kinds LIKE ?", "%"+query+"%")
-		db = d.conn.Where("colour LIKE ?", "%"+query+"%")
-		db = d.conn.Where("situation LIKE ?", "%"+query+"%")
-		db = d.conn.Where("others LIKE ?", "%"+query+"%")
-	}
-	for _, tag := range tags {
-		db = d.conn.Where("Kinds LIKE ?", "%"+tag+"%")
+	var db *gorm.DB
+	if len(query) > 0 {
+		// queryが存在する場合
+		db = d.conn.Where("(")
+		for i, q := range query {
+			db = db.Where("column LIKE ? OR other LIKE ? OR Situation LIKE ? OR Kinds LIKE ?", q, q, q, q)
+			if i < len(query)-1 {
+				db = db.Where("AND ")
+			}
+		}
+		db = db.Where(")")
 	}
 
 	items := make([]database.LostItem, d.limit)
-	db = db.Limit(int(d.limit)).Find(&items)
+	if len(query) > 0 {
+		db = db.Where("? <= Lat AND Lat <= ? AND ? <= Lng AND Lng <= ?", bottom, upper, left, right).Limit(int(d.limit)).Find(&items)
+	} else {
+		db = d.conn.Where("? <= Lat AND Lat <= ? AND ? <= Lng AND Lng <= ?", bottom, upper, left, right).Limit(int(d.limit)).Find(&items)
+	}
 	if db.RowsAffected == 0 {
 		return model.SearchResult{
 			Count: 0,

--- a/back/database/postgresd/postgresd.go
+++ b/back/database/postgresd/postgresd.go
@@ -95,20 +95,18 @@ func (d *Postgresd) Search(left_upper model.Location, right_bottom model.Locatio
 	}
 
 	var db *gorm.DB
-	if len(query) > 0 {
-		// queryが存在する場合
-		db = d.conn.Where("(")
-		for i, q := range query {
+	// queryが存在する場合
+	if query != "" {
+		// 空白分け
+		queries := strings.Fields(query)
+		db = d.conn
+		for _, q := range queries {
 			db = db.Where("column LIKE ? OR other LIKE ? OR Situation LIKE ? OR Kinds LIKE ?", q, q, q, q)
-			if i < len(query)-1 {
-				db = db.Where("AND ")
-			}
 		}
-		db = db.Where(")")
 	}
 
 	items := make([]database.LostItem, d.limit)
-	if len(query) > 0 {
+	if query != "" {
 		db = db.Where("? <= Lat AND Lat <= ? AND ? <= Lng AND Lng <= ?", bottom, upper, left, right).Limit(int(d.limit)).Find(&items)
 	} else {
 		db = d.conn.Where("? <= Lat AND Lat <= ? AND ? <= Lng AND Lng <= ?", bottom, upper, left, right).Limit(int(d.limit)).Find(&items)


### PR DESCRIPTION
<!--
不要な場合は削除してください
-->

## タスク
https://github.com/yuorei/lost-item-backend/issues/48
<!--
何を実装しますか？
-->

## 仕様
queryにも対応した
<!--
どのようにを実装しましたか？
-->

## 動作確認
```
SELECT * FROM "lost_items" WHERE ( AND (column LIKE 36196 OR other LIKE 36196 OR Situation LIKE 36196 OR Kinds LIKE 36196) AND AND  AND (column LIKE 12288 OR other LIKE 12288 OR Situation LIKE 12288 OR Kinds LIKE 12288) AND AND  AND (column LIKE 38738 OR other LIKE 38738 OR Situation LIKE 38738 OR Kinds LIKE 38738) AND AND  AND ) AND (35.657608 <= Lat AND Lat <= 35.696444 AND 139.750435 <= Lng AND Lng <= 139.791456) AND "lost_items"."deleted_at" IS NULL LIMIT 100
```

```
SELECT * FROM "lost_items" WHERE (35.657608 <= Lat AND Lat <= 35.696444 AND 139.750435 <= Lng AND Lng <= 139.791456) AND "lost_items"."deleted_at" IS NULL LIMIT 100
```
<!--
何をチェックしましたか？
-->

## チェックシート
- [ ] 他の人が見ても読みやすいコードを書いた
- [ ] コードを読んでも分かりにくいところはコメントをのこした
- [x] 動作確認で動いた
